### PR TITLE
Fix kerberos authentication & no-pass

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -278,7 +278,7 @@ def main():
     if args.username is not None and args.password is not None:
         logging.debug('Authentication: username/password')
         auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method, ldap_channel_binding=args.ldap_channel_binding)
-    elif args.username is not None and args.password is None and args.hashes is None and args.aesKey is None and args.no_pass is not None:
+    elif args.username is not None and args.password is None and args.hashes is None and args.aesKey is None and args.no_pass is not True:
         args.password = getpass.getpass()
         auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method, ldap_channel_binding=args.ldap_channel_binding)
     elif args.username is None and (args.password is not None or args.hashes is not None):


### PR DESCRIPTION
Hello

I had issues with Kerberos authentication and with using no-pass (the original BloodHound.py also has these 2 issues). 
I've tested this against a test domain and worked for me:

Error message: 
```
  File "/home/kali/.local/share/pipx/venvs/bloodhound/lib/python3.12/site-packages/gssapi/sec_contexts.py", line 606, in _initiator_step
    res = rsec_contexts.init_sec_context(self._target_name, self._creds,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "gssapi/raw/sec_contexts.pyx", line 188, in gssapi.raw.sec_contexts.init_sec_context
gssapi.raw.misc.GSSError: Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2529638919): Server not found in Kerberos database
```

Thanks!